### PR TITLE
chore: add repository and bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "Linter for JS vanilla projects",
   "main": "index.js",
   "type": "module",
+  "bugs": {
+    "url": "https://github.com/ManzDev/eslint-config-manzdev/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ManzDev/eslint-config-manzdev.git"
+  },
   "scripts": {
     "test": "pnpm dlx eslint -c index.js"
   },


### PR DESCRIPTION
Se añadieron los metadatos de `repository` y `bugs` al archivo `package.json` para mejorar las previsualización de la información en https://www.npmjs.com/package/eslint-config-manzdev.